### PR TITLE
Fix showing 2 notifications in certain scenarios

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -5,6 +5,14 @@ chrome.storage.local.set({'last_notification': ''});
 var interface_port = null, popup_port = null;
 var loader_ports = {};
 
+
+// Listen for spotify to open
+chrome.tabs.onUpdated.addListener(function(tabId, changeInfo,tab) {
+    if (tab.url.indexOf("open.spotify.com") > -1 && changeInfo.url === undefined) {
+        chrome.tabs.executeScript(tabId, {file: "scripts/loader.js"});
+    }
+});
+
 chrome.runtime.onConnect.addListener(function(port) {
 
   if (port.name == "loader") {

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -6,10 +6,12 @@ var interface_port = null, popup_port = null;
 var loader_ports = {};
 
 chrome.runtime.onConnect.addListener(function(port) {
+
   if (port.name == "loader") {
     port.id = port.sender.tab.id;
     loader_ports[port.id] = port;
     port.onMessage.addListener(function(msg) {
+
       if (msg.protocol) {
         chrome.tabs.executeScript(port.id, {file: "scripts/enums.js"});
         chrome.tabs.executeScript(port.id, {file: "scripts/protocols/global.js"});
@@ -22,15 +24,18 @@ chrome.runtime.onConnect.addListener(function(port) {
       loader_ports[port.id] = null;
     });
   }
-  if (port.name == "interface" && !interface_port) {
+  if (port.name == "interface" /*&& !interface_port*/) {
+
     interface_port = port;
     interface_port.id = port.sender.tab.id;
     port.onMessage.addListener(function(msg) {
-      if (msg.scrobble == true) {
-        scrobble(msg.oldValue);
-      }
+
+      // if (msg.scrobble == true) {
+      //   scrobble(msg.oldValue);
+      // }
       if (msg.notify == true) {
-        create_notification(msg.newValue);
+        //create_notification(msg.newValue);
+        notify_helper(msg.newValue, msg.newValue.album_art);
         now_playing(msg.newValue);
       }
     });
@@ -54,7 +59,7 @@ chrome.runtime.onConnect.addListener(function(port) {
 });
 
 function notify_helper(details, url) {
-  chrome.notifications.create('',
+  chrome.notifications.create('100',
   {
     type: 'basic',
     title: details.title,
@@ -71,12 +76,7 @@ function notify_helper(details, url) {
         iconUrl: 'img/notification_ff.png'
       }]
   }, function(id){
-    chrome.storage.local.get('last_notification', function (data) {
-      if (data['last_notification']) {
-        chrome.notifications.clear(data['last_notification'], function(cleared){});
-      }
-      chrome.storage.local.set({'last_notification': id});
-    });
+    console.log('notified', id);
   });
 }
 

--- a/scripts/controllers.js
+++ b/scripts/controllers.js
@@ -42,7 +42,7 @@ var controller = popupApp.controller('PopupController', ['$scope', function($sco
       thumb: ThumbEnum.NONE,
       artist_id: '',
       album_id: '',
-      protocol: 'gmusic'
+      protocol: 'spotify'
     };
 
     $scope.data = {
@@ -403,6 +403,7 @@ var controller = popupApp.controller('PopupController', ['$scope', function($sco
 
       $scope.background_port.onMessage.addListener(function(msg) {
         if (msg.type == 'connect') {
+
           $scope.interface_port = chrome.tabs.connect(msg.id, {name: "popup"});
           $scope.interface_port.id = msg.id;
           $scope.interface_port.onDisconnect.addListener(function() {
@@ -492,6 +493,7 @@ var controller = popupApp.controller('PopupController', ['$scope', function($sco
         }
         else {
           $.extend($scope.music_status, response);
+
           if (response.title === '') {
             $scope.$apply(function() {
               $scope.set_state(StateEnum.NO_SONG);

--- a/scripts/loader.js
+++ b/scripts/loader.js
@@ -4,10 +4,11 @@ function load() {
     gmusic: "play.google.com/music",
     pandora: "pandora.com",
     songza: "songza.com",
-    spotify: "play.spotify.com"
+    spotify: "open.spotify.com"
   };
 
   var background_port = chrome.runtime.connect({name: "loader"});
+
   for (var protocol in urls) {
     if (urls.hasOwnProperty(protocol) && document.URL.search(urls[protocol]) > 0) {
       background_port.postMessage({"protocol": protocol});

--- a/scripts/protocols/global.js
+++ b/scripts/protocols/global.js
@@ -45,6 +45,12 @@ function create_background_msg(oldValue, newValue) {
     if (newValue.title != '') {
       msg.notify = true;
     }
+
+    // Do not send if music isn't playing
+    if (newValue.status == StatusEnum.PAUSED) {
+        return null;
+    }
+
     return msg;
   }
   else {

--- a/scripts/protocols/global.js
+++ b/scripts/protocols/global.js
@@ -28,12 +28,12 @@ function create_background_msg(oldValue, newValue) {
   if (oldValue !== undefined && (oldValue.title != newValue.title ||
       oldValue.artist != newValue.artist || oldValue.album_art != newValue.album_art)) {
 
-    // There's a bug wwhere 2 notifications are shown sometimes
+    // There's a bug where 2 notifications are shown sometimes
     // because the album artwork takes a while to load. The first
     // notification will have the new title and artist, but old artwork.
     //
     // This fix prevents that notification from being displayed, showing
-    // the notification only once the new artwork is also fetched.
+    // the notification only once the new artwork is also fetched.p
     if (oldValue.title != newValue.title && oldValue.artist != newValue.artist &&
        oldValue.album_art == newValue.album_art) {
       return null;

--- a/scripts/protocols/global.js
+++ b/scripts/protocols/global.js
@@ -9,6 +9,7 @@ function update() {
     old_status = JSON.parse(JSON.stringify(music_status));
     music_status.update();
     var msg = create_background_msg(old_status, music_status);
+
     if (msg != null) {
       background_port.postMessage(msg);
     }
@@ -25,6 +26,7 @@ function create_background_msg(oldValue, newValue) {
   var msg = {scrobble: false, notify: false};
   msg.oldValue = oldValue;
   msg.newValue = newValue;
+
   if (oldValue !== undefined && (oldValue.title != newValue.title ||
       oldValue.artist != newValue.artist || oldValue.album_art != newValue.album_art)) {
 

--- a/scripts/protocols/global.js
+++ b/scripts/protocols/global.js
@@ -18,6 +18,7 @@ function update() {
         'data': music_status
       });
     }
+
   }
 }
 
@@ -27,6 +28,13 @@ function create_background_msg(oldValue, newValue) {
   msg.newValue = newValue;
   if (oldValue !== undefined && (oldValue.title != newValue.title ||
       oldValue.artist != newValue.artist || oldValue.album_art != newValue.album_art)) {
+
+    // hacky check for fake out
+    if (oldValue.title != newValue.title && oldValue.artist != newValue.artist &&
+       oldValue.album_art == newValue.album_art) {
+      return null;
+    }
+
     msg.scrobble = true;
     if (newValue.title != '') {
       msg.notify = true;

--- a/scripts/protocols/global.js
+++ b/scripts/protocols/global.js
@@ -18,7 +18,6 @@ function update() {
         'data': music_status
       });
     }
-
   }
 }
 
@@ -29,7 +28,12 @@ function create_background_msg(oldValue, newValue) {
   if (oldValue !== undefined && (oldValue.title != newValue.title ||
       oldValue.artist != newValue.artist || oldValue.album_art != newValue.album_art)) {
 
-    // hacky check for fake out
+    // There's a bug wwhere 2 notifications are shown sometimes
+    // because the album artwork takes a while to load. The first
+    // notification will have the new title and artist, but old artwork.
+    //
+    // This fix prevents that notification from being displayed, showing
+    // the notification only once the new artwork is also fetched.
     if (oldValue.title != newValue.title && oldValue.artist != newValue.artist &&
        oldValue.album_art == newValue.album_art) {
       return null;

--- a/scripts/protocols/spotify/interface.js
+++ b/scripts/protocols/spotify/interface.js
@@ -31,6 +31,18 @@ function update_slider(position, slider) {  //position is in %
 
 function send_command(message) {
   var iframe = document.querySelector('#app-player').contentDocument;
+  var track = document.querySelector('div.track-info-name');
+
+  chrome.notifications.create('42', {
+    type: 'basic',
+    title: 'test track',
+    message: 'name; ' + track,
+    contextMessage: 'test context',
+    iconUrl: 'https://chambermaster.blob.core.windows.net/userfiles/UserFiles/chambers/2219/Image/christmas-tree-clip-art-xmas_christmas_tree_5-3333px.png'
+  }, function(id) {
+    console.log('id', id);
+  });
+
   var button = null;
   switch (message.type) {
     case 'play':

--- a/scripts/protocols/spotify/status.js
+++ b/scripts/protocols/spotify/status.js
@@ -24,7 +24,6 @@ var music_status = {
 
   get_album_art : function () {
     var artworkDOM = document.querySelector('div.now-playing');
-    console.log('artwork', artworkDOM);
     var artworkURL = null;
 
     if (artworkDOM) {

--- a/scripts/protocols/spotify/status.js
+++ b/scripts/protocols/spotify/status.js
@@ -23,7 +23,7 @@ var music_status = {
   },
 
   get_album_art : function () {
-    var artworkDOM = document.querySelector('div.now-playing');
+    var artworkDOM = document.querySelector('div.now-playing-bar');
     var artworkURL = null;
 
     if (artworkDOM) {
@@ -43,11 +43,11 @@ var music_status = {
 
   update : function() {
 
-    var nowPlayingContent = document.querySelector('.now-playing');
+    var nowPlayingContent = document.querySelector('.now-playing-bar');
     var trackInfo = nowPlayingContent.querySelector('.track-info');
 
-    this.title = trackInfo.querySelector('.track-info-name > a').innerText;
-    this.artist = trackInfo.querySelector('.track-info-artists > span > a').innerText;
+    this.title = nowPlayingContent.querySelector('div.react-contextmenu-wrapper > a').innerText;
+    this.artist = nowPlayingContent.querySelector('span > a').innerText;
     this.album_art = this.get_album_art();
     this.protocol = 'spotify';
     this.status = this.get_play_pause_status();

--- a/scripts/protocols/spotify/status.js
+++ b/scripts/protocols/spotify/status.js
@@ -23,23 +23,39 @@ var music_status = {
   },
 
   get_album_art : function () {
-    var url = getComputedStyle(document.querySelector('#app-player').contentDocument.querySelector('.sp-image-img'))['background-image'];
-    return url ? url.substring(url.search('http'), url.indexOf(')') - 1) : 'img/default_album.png';
+    var artworkDOM = document.querySelector('div.now-playing');
+    console.log('artwork', artworkDOM);
+    var artworkURL = null;
+
+    if (artworkDOM) {
+      var bgImage = artworkDOM.querySelector('.cover-art-image').style['background-image'];
+      artworkURL = bgImage.substring(bgImage.search('http'), bgImage.indexOf(')') - 1);
+    }
+
+    return artworkURL ? artworkURL : 'img/default_album.png';
+  },
+
+  get_play_pause_status: function() {
+    var pauseButton = document.querySelector('.spoticon-pause-32');
+    var playButton = document.querySelector('.spoticon-play-32');
+
+    return playButton ? StatusEnum.PAUSED : StatusEnum.PLAYING;
   },
 
   update : function() {
-    var iframe = document.querySelector('#app-player').contentDocument;
-    this.title = iframe.querySelector('#track-name > a').innerText;
-    this.artist = iframe.querySelector('#track-artist > a').innerText;
+
+    var nowPlayingContent = document.querySelector('.now-playing');
+    var trackInfo = nowPlayingContent.querySelector('.track-info');
+
+    this.title = trackInfo.querySelector('.track-info-name > a').innerText;
+    this.artist = trackInfo.querySelector('.track-info-artists > span > a').innerText;
     this.album_art = this.get_album_art();
-    this.current_time = iframe.querySelector('#track-current').innerText;
-    this.total_time = iframe.querySelector('#track-length').innerText;
-    this.current_time_s = this.get_time(this.current_time);
-    this.total_time_s = this.get_time(this.total_time);
-    this.repeat = iframe.querySelector('#repeat').classList.contains('active') ? RepeatEnum.ALL : RepeatEnum.NONE;
-    this.shuffle = iframe.querySelector('#shuffle').classList.contains('active');
-    this.status = (iframe.querySelector('#play-pause').classList.contains('playing')) ? StatusEnum.PLAYING : StatusEnum.PAUSED;
-    this.volume = parseFloat(getComputedStyle(iframe.querySelector('#vol-position')).left, 10) / 108 * 100;
+    this.protocol = 'spotify';
+    this.status = this.get_play_pause_status();
+
+    var volumeStr = document.querySelector('.volume-bar > div > div > div').style.width;
+    this.volume = parseInt(volumeStr.substring(0, volumeStr.length - 2));
+
     return this;
   }
 };


### PR DESCRIPTION
In certain cases, the album artwork of a song can take a while to load. When this happens, 2 notifications are shown: 1 with the last songs artwork, and 1 with the correct artwork. This fix ensures that in these scenarios only the second notification is shown.

There is probably a better way to do this, so if there is feel free to let me know the best way to fix this particular issue.